### PR TITLE
hw2/time-to-live: ✨ added time-to-live feature

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -11,14 +11,14 @@ type value struct {
 }
 
 type db struct {
-	t    *time.Ticker
-	data sync.Map
+	ticker *time.Ticker
+	data   sync.Map
 }
 
 func New() *db {
 	db := &db{
-		t:    time.NewTicker(time.Second * 1),
-		data: sync.Map{},
+		ticker: time.NewTicker(time.Second * 1),
+		data:   sync.Map{},
 	}
 
 	go db.backgroundCacheCleaner()
@@ -29,7 +29,7 @@ func New() *db {
 // background goroutine to clean up expired keys in the cache
 func (db *db) backgroundCacheCleaner() {
 	for {
-		<-db.t.C
+		<-db.ticker.C
 		db.data.Range(func(key, v interface{}) bool {
 			vv, ok := v.(*value)
 			if !ok {
@@ -49,12 +49,7 @@ func (db *db) backgroundCacheCleaner() {
 	}
 }
 
-// Set sets a key to a value in the cache forever.
-func (db *db) Set(key string, v interface{}) {
-	db.data.Store(key, &value{v, nil})
-}
-
-func (db *db) SetWithTimeout(key string, v interface{}, ttl time.Duration) {
+func (db *db) Set(key string, v interface{}, ttl time.Duration) {
 	t := time.Now().Add(ttl)
 	db.data.Store(key, &value{v, &t})
 }

--- a/cache.go
+++ b/cache.go
@@ -2,24 +2,75 @@ package cache
 
 import (
 	"sync"
+	"time"
 )
 
+type value struct {
+	value interface{}
+	ttl   *time.Time
+}
+
 type db struct {
+	t    *time.Ticker
 	data sync.Map
 }
 
 func New() *db {
-	return &db{
+	db := &db{
+		t:    time.NewTicker(time.Second * 1),
 		data: sync.Map{},
+	}
+
+	go db.backgroundCacheCleaner()
+
+	return db
+}
+
+// background goroutine to clean up expired keys in the cache
+func (db *db) backgroundCacheCleaner() {
+	for {
+		<-db.t.C
+		db.data.Range(func(key, v interface{}) bool {
+			vv, ok := v.(*value)
+			if !ok {
+				return true
+			}
+
+			if vv.ttl == nil {
+				return true
+			}
+
+			if time.Now().After(*vv.ttl) {
+				db.data.Delete(key)
+			}
+
+			return true
+		})
 	}
 }
 
-func (db *db) Set(key string, value interface{}) {
-	db.data.Store(key, value)
+// Set sets a key to a value in the cache forever.
+func (db *db) Set(key string, v interface{}) {
+	db.data.Store(key, &value{v, nil})
+}
+
+func (db *db) SetWithTimeout(key string, v interface{}, ttl time.Duration) {
+	t := time.Now().Add(ttl)
+	db.data.Store(key, &value{v, &t})
 }
 
 func (db *db) Get(key string) (result interface{}, ok bool) {
-	return db.data.Load(key)
+	load, ok := db.data.Load(key)
+	if !ok {
+		return nil, false
+	}
+
+	vv, ok := load.(*value)
+	if !ok {
+		return nil, false
+	}
+
+	return vv.value, true
 }
 
 func (db *db) Delete(key string) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -10,22 +10,8 @@ var cache *db
 func TestSet(t *testing.T) {
 	createCache(t)
 
-	cache.Set("key", "value")
-
-	result, ok := cache.Get("key")
-	if !ok {
-		t.Error("Expected value to be 'value'")
-	}
-	if result != "value" {
-		t.Error("Expected value to be 'value'")
-	}
-}
-
-func TestSetWithTimeout(t *testing.T) {
-	createCache(t)
-
 	t.Run("Get", func(t *testing.T) {
-		cache.SetWithTimeout("key", "value", time.Millisecond*1)
+		cache.Set("key", "value", time.Millisecond*1)
 
 		result, ok := cache.Get("key")
 		if !ok {
@@ -39,7 +25,7 @@ func TestSetWithTimeout(t *testing.T) {
 	t.Run("wait for the key to expire", func(t *testing.T) {
 		t.Parallel()
 
-		cache.SetWithTimeout("key", "value", time.Microsecond*1)
+		cache.Set("key", "value", time.Microsecond*1)
 
 		time.Sleep(time.Second * 2)
 
@@ -56,7 +42,7 @@ func TestSetWithTimeout(t *testing.T) {
 func TestGet(t *testing.T) {
 	createCache(t)
 
-	cache.Set("key", "value")
+	cache.Set("key", "value", time.Microsecond*1)
 
 	result, ok := cache.Get("key")
 	if !ok {
@@ -70,7 +56,7 @@ func TestGet(t *testing.T) {
 func TestDelete(t *testing.T) {
 	createCache(t)
 
-	cache.Set("key", "value")
+	cache.Set("key", "value", time.Microsecond*1)
 	cache.Delete("key")
 
 	result, ok := cache.Get("key")

--- a/cache_test.go
+++ b/cache_test.go
@@ -41,7 +41,7 @@ func TestSetWithTimeout(t *testing.T) {
 
 		cache.SetWithTimeout("key", "value", time.Microsecond*1)
 
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Second * 2)
 
 		result, ok := cache.Get("key")
 		if ok {

--- a/cache_test.go
+++ b/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 )
 
 var cache *db
@@ -18,6 +19,38 @@ func TestSet(t *testing.T) {
 	if result != "value" {
 		t.Error("Expected value to be 'value'")
 	}
+}
+
+func TestSetWithTimeout(t *testing.T) {
+	createCache(t)
+
+	t.Run("Get", func(t *testing.T) {
+		cache.SetWithTimeout("key", "value", time.Millisecond*1)
+
+		result, ok := cache.Get("key")
+		if !ok {
+			t.Error("Expected value to be 'value'")
+		}
+		if result != "value" {
+			t.Error("Expected value to be 'value'")
+		}
+	})
+
+	t.Run("wait for the key to expire", func(t *testing.T) {
+		t.Parallel()
+
+		cache.SetWithTimeout("key", "value", time.Microsecond*1)
+
+		time.Sleep(time.Second * 1)
+
+		result, ok := cache.Get("key")
+		if ok {
+			t.Error("Expected value to be nil")
+		}
+		if result != nil {
+			t.Error("Expected value to be nil")
+		}
+	})
 }
 
 func TestGet(t *testing.T) {


### PR DESCRIPTION
# Реализовать TTL (Time-To-Live) для кэша из прошлого ДЗ

Нужно реализовать следующую логику: при вызове метода `Set(key string, value interface{}, ttl time.Duration)` передается дополнительный аргумент для ttl типа time.Duration, спустя которое значение будет очищено с кэша.